### PR TITLE
Use the endian.h header to detect endianness.

### DIFF
--- a/src/font/irrUString.h
+++ b/src/font/irrUString.h
@@ -37,6 +37,7 @@
 #	endif
 #endif
 
+#include <endian.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -181,7 +182,7 @@ inline core::array<u8> getUnicodeBOM(EUTF_ENCODE mode)
 			COPY_ARRAY(BOM_ENCODE_UTF8, BOM_ENCODE_UTF8_LEN);
 			break;
 		case EUTFE_UTF16:
-			#ifdef __BIG_ENDIAN__
+			#if BYTE_ORDER == BIG_ENDIAN
 				COPY_ARRAY(BOM_ENCODE_UTF16_BE, BOM_ENCODE_UTF16_LEN);
 			#else
 				COPY_ARRAY(BOM_ENCODE_UTF16_LE, BOM_ENCODE_UTF16_LEN);
@@ -194,7 +195,7 @@ inline core::array<u8> getUnicodeBOM(EUTF_ENCODE mode)
 			COPY_ARRAY(BOM_ENCODE_UTF16_LE, BOM_ENCODE_UTF16_LEN);
 			break;
 		case EUTFE_UTF32:
-			#ifdef __BIG_ENDIAN__
+			#if BYTE_ORDER == BIG_ENDIAN
 				COPY_ARRAY(BOM_ENCODE_UTF32_BE, BOM_ENCODE_UTF32_LEN);
 			#else
 				COPY_ARRAY(BOM_ENCODE_UTF32_LE, BOM_ENCODE_UTF32_LEN);
@@ -810,7 +811,7 @@ public:
 	ustring16()
 	: array(0), allocated(1), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -824,7 +825,7 @@ public:
 	ustring16(const ustring16<TAlloc>& other)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -838,7 +839,7 @@ public:
 	ustring16(const string<B, A>& other)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -853,7 +854,7 @@ public:
 	ustring16(const std::basic_string<B, A, Alloc>& other)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -867,7 +868,7 @@ public:
 	ustring16(Itr first, Itr last)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -886,7 +887,7 @@ public:
 	ustring16(const char* const c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -901,7 +902,7 @@ public:
 	ustring16(const char* const c, size_t length)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -916,7 +917,7 @@ public:
 	ustring16(const uchar8_t* const c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -930,7 +931,7 @@ public:
 	ustring16(const char c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -944,7 +945,7 @@ public:
 	ustring16(const uchar8_t* const c, size_t length)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -958,7 +959,7 @@ public:
 	ustring16(const uchar16_t* const c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -972,7 +973,7 @@ public:
 	ustring16(const uchar16_t* const c, size_t length)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -986,7 +987,7 @@ public:
 	ustring16(const uchar32_t* const c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -1000,7 +1001,7 @@ public:
 	ustring16(const uchar32_t* const c, size_t length)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -1014,7 +1015,7 @@ public:
 	ustring16(const wchar_t* const c)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;
@@ -1033,7 +1034,7 @@ public:
 	ustring16(const wchar_t* const c, size_t length)
 	: array(0), allocated(0), used(0)
 	{
-#if __BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 		encoding = unicode::EUTFE_UTF16_BE;
 #else
 		encoding = unicode::EUTFE_UTF16_LE;


### PR DESCRIPTION
The next version of POSIX provides an endian.h header with defined symbols BYTE_ORDER, BIG_ENDIAN, and LITTLE_ENDIAN. This allows us to check endianness in a standard fashion.

endian.h is provided at least by Linux, OpenBSD, and other modern BSDs. The current code with __BIG_ENDIAN__ (which is nonstandard) doesn’t build on OpenBSD/sparc64.